### PR TITLE
Update plugin to use new Menu Entry API for RLv1.8.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.6'
+def runeLiteVersion = '1.8.7-SNAPSHOT'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion


### PR DESCRIPTION
RuneLite version 1.8.7+ will use a new API to handle menu entries, relying on callbacks rather than subscribing to events. This commit updates the plugin to the new API version.